### PR TITLE
Upgrade to latest Malli to use `mu/keys`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ pom.xml.asc
 *.class
 /.nrepl-port
 .cpcache/
-.clj-kondo/.cache
+.clj-kondo/
+!.clj-kondo/config.edn
+.calva/
+.portal/
+.lsp/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,4 @@ pom.xml.asc
 *.class
 /.nrepl-port
 .cpcache/
-.clj-kondo/
-!.clj-kondo/config.edn
-.calva/
-.portal/
-.lsp/.cache
+.clj-kondo/.cache

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
   camel-snake-kebab/camel-snake-kebab
   {:mvn/version "0.4.3"}
   metosin/malli
-  {:mvn/version "0.8.4"}}
+  {:mvn/version "0.8.8"}}
  :aliases
  {:build
   {:deps

--- a/src/org/passen/malapropism/core.clj
+++ b/src/org/passen/malapropism/core.clj
@@ -6,19 +6,10 @@
    [clojure.tools.logging :as log]
    [malli.core :as m]
    [malli.error :as me]
-   [malli.transform :as mt])
+   [malli.transform :as mt]
+   [malli.util :as mu])
   (:import
    (java.io PushbackReader)))
-
-(defn- schema-keys
-  [config-schema]
-  (m/walk
-   config-schema
-   (fn [schema _ children _options]
-     (let [children (if (m/entries schema)
-                      (filter last children)
-                      children)]
-       (map first children)))))
 
 (defn with-schema
   [config-schema]
@@ -26,7 +17,7 @@
 
 (defn with-values-from-map
   [[config-schema config-values] m]
-  (let [values (select-keys m (schema-keys config-schema))]
+  (let [values (select-keys m (mu/keys config-schema))]
     (log/infof "Populating, %d values" (count values))
     [config-schema (merge config-values values)]))
 


### PR DESCRIPTION
This makes the `schema-keys` function unnecessary!

The latest Malli added some additional clj-kondo directories; so did Calva and Portal. I added them to `.gitignore` and whitelisted `.clj-kondo/config.edn`.

All existing tests pass.